### PR TITLE
Fix trial payments

### DIFF
--- a/lib/active_merchant/billing/gateways/recurly.rb
+++ b/lib/active_merchant/billing/gateways/recurly.rb
@@ -73,6 +73,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
+        return trial_payment_uuid if trial_payment?
         response['uuid'].presence || invoice['transactions'][0]['uuid']
       end
 
@@ -110,6 +111,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from
+        return trial_payment_status if trial_payment?
         invoice['transactions'][0]['status']
       end
 
@@ -138,6 +140,18 @@ module ActiveMerchant #:nodoc:
 
       def url
         "https://v3.recurly.com/sites/subdomain-#{@options[:subdomain]}/"
+      end
+
+      def trial_payment?
+        invoice['transactions'].empty? and invoice["paid"] == 0.0
+      end
+
+      def trial_payment_status
+        return invoice["state"]
+      end
+
+      def trial_payment_uuid
+        return invoice["line_items"]["data"].first["uuid"]
       end
     end
   end


### PR DESCRIPTION
## Warning!!! Merge this only after  https://github.com/Etison/mothership/pull/10206 has been merged in master and QA accepted ##

### Overview

The issue occurs for Recurly  subscription plans with a trial period and without any setup fee.

When this happens, the response returned by Recurly API doesn't have any transactions, so in order to grab the **message status** and the **authorization uuid**, we have to process the invoice differently for this type of payment by using the `line_items` structure and the invoice state.

* Example of request response **WITHOUT** setup fee

```
{
  ...
  "state"=>"paid",
  "paid"=>0.0,
  "total"=>0.0,
  "subtotal"=>0.0,
  "refundable_amount"=>0.0,
  "transactions"=>[],
  "line_items"=> 
  { 
    ..., 
    "data"=>
    [
      { 
        ...
        "uuid"=>"...", 
       }
    ]
  }
}
```

* Example of request response **WITH** setup fee

```
{
  ...
  "state"=>"paid",
  "paid"=>10.0,
  "total"=>10.0,
  "subtotal"=>10.0,
  "refundable_amount"=>10.0,
  "transactions"=>
  [
    {
      ...,
      "id"=>"...",
    }
  ],
  "line_items"=> 
  { 
    ..., 
    "data"=>
    [
      { 
        ...
        "uuid"=>"...", 
      }
    ]
  }
}
```

It is possible to see the plan setup fee configuration in Recurly by visiting `Configuration -> Plans` and then select your plan. The section showing the setup fee configuration is this one:

![Screenshot on 2020-05-30 at 22_08_17](https://user-images.githubusercontent.com/1770506/83342154-1cdfb700-a2c2-11ea-9b21-f45fcca39ebc.png)


### Pivotal Tracker Links

https://www.pivotaltracker.com/story/show/173013712

### Dependency Updates

None